### PR TITLE
Add support to compile using third-party GCC and little changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Or use the [preset workflow file](https://github.com/dabao1955/kernel_build_acti
  | nethunter-patch | false | | false |
 | kvm | false | | false |
 | ccache | false | Enable ccache(Only valid when compiled with clang) | false |
-| aosp-gcc |true | Use aosp-gcc to compile the kernel or assist in compiling the kernel (when aosp-clang is enabled) | false |
+| aosp-gcc | false | Use aosp-gcc to compile the kernel or assist in compiling the kernel (when aosp-clang is enabled) | false |
 | other-gcc32-url | false | Please fill in the download link of other gcc32 in this option. Supports .xz, .zip, .tar and .git formats | https://github.com/username/gcc |
 | other-gcc32-branch | false | | main |
 | other-gcc64-url | false | Please fill in the download link of other gcc64 in this option. Supports .xz, .zip, .tar and .git formats | https://github.com/username/gcc |
@@ -102,6 +102,7 @@ Or use the [preset workflow file](https://github.com/dabao1955/kernel_build_acti
 | access-token | false | Please fill it if you want to release kernel | ghp_xxxxxx |
 | bootimg-url | false | A URL that can download the local boot.img | https://127.0.0.1/boot.img |
 | extra-cmd | false | Compile the kernel with extra options, such as LD=ld.lld | AS=llvm-as |
+| include-dtbo | false | Include DTBO image in kernel package | true |
 
 ## FAQ
 > [!CAUTION]

--- a/action.yml
+++ b/action.yml
@@ -141,6 +141,10 @@ inputs:
     description: 'Extra options of building kernel.'
     required: false
     default: ""
+  include-dtbo:
+    description: 'Include DTBO image in kernel package'
+    required: false
+    default: true
 
 runs:
   using: 'composite'
@@ -472,7 +476,9 @@ runs:
                 cp out/arch/${{ inputs.arch }}/boot/Image AnyKernel3/ -rv
             fi
 
-            test -f out/arch/${{ inputs.arch }}/boot/dtbo.img && cp -v out/arch/${{ inputs.arch }}/boot/dtbo.img AnyKernel3/
+            if [ ${{ inputs.include-dtbo }} = true ]; then
+                test -f out/arch/${{ inputs.arch }}/boot/dtbo.img && cp -v out/arch/${{ inputs.arch }}/boot/dtbo.img AnyKernel3/
+            fi
 
             rm -rf -v AnyKernel3/.git* AnyKernel3/README.md
             if [ ${{ inputs.release }} = false ]; then

--- a/action.yml
+++ b/action.yml
@@ -214,6 +214,10 @@ runs:
                      aria2c -o "${output_name}.tar.xz" "$url"
                      tar -C "$extract_dir" -xf "${output_name}.tar.xz"
                      ;;
+                 *.xz)
+                     aria2c -o "${output_name}.xz" "$url"
+                     tar -C "$extract_dir" -xf "${output_name}.xz"
+                     ;;
                  *)
                      git clone "$url" "$extract_dir" --depth=${{ inputs.depth }} -b "$branch"
                      ;;

--- a/action.yml
+++ b/action.yml
@@ -403,13 +403,13 @@ runs:
          echo "::group:: Building Kernel with selected cross compiler"
          mkdir out -p -v
          COMMAND="make -j$(nproc --all) ${{ inputs.config }} ARCH=${{ inputs.arch }} all ${{ inputs.extra-cmd }} O=out"
-         if [ -d $HOME/clang ]; then
+         if [ -d $HOME/clang/bin ]; then
               COMMAND+=" PATH=$HOME/clang/bin:$PATH"
          fi
          if [ -d $HOME/gcc-64/bin ] || [ -d $HOME/gcc-32/bin ]; then
              COMMAND+=" CROSS_COMPILE=$HOME/gcc-64/bin/${GCC64}- CROSS_COMPILE_ARM32=$HOME/gcc-32/bin/${GCC32}- CLANG_TRIPLE=aarch64-linux-gnu-"
          fi
-         if [ -d $HOME/clang ]; then
+         if [ -d $HOME/clang/bin ]; then
              if [ ${{ inputs.ccache }} = true ]; then
                  COMMAND+=" CC='ccache clang'"
              else

--- a/action.yml
+++ b/action.yml
@@ -406,7 +406,7 @@ runs:
          if [ -d $HOME/clang ]; then
               COMMAND+=" PATH=$HOME/clang/bin:$PATH"
          fi
-         if [ ${{ inputs.aosp-gcc }} = true ]; then
+         if [ -d $HOME/gcc-64/bin ] || [ -d $HOME/gcc-32/bin ]; then
              COMMAND+=" CROSS_COMPILE=$HOME/gcc-64/bin/${GCC64}- CROSS_COMPILE_ARM32=$HOME/gcc-32/bin/${GCC32}- CLANG_TRIPLE=aarch64-linux-gnu-"
          fi
          if [ -d $HOME/clang ]; then
@@ -415,13 +415,12 @@ runs:
              else
                  COMMAND+=" CC=clang"
              fi
-         else
-             if [ ${{ inputs.ccache }} = true ]; then
-                 if [ -n "${GCC64}" ]; then
-                     COMMAND+=" CC='ccache $HOME/gcc-64/bin/${GCC64}-gcc'"
-                 else
-                     COMMAND+=" CC='ccache $HOME/gcc-32/bin/${GCC32}-gcc'"
-                 fi
+         fi
+         if [ ${{ inputs.ccache }} = true ]; then
+             if [ -n "${GCC64}" ]; then
+                 COMMAND+=" CC='ccache $HOME/gcc-64/bin/${GCC64}-gcc'"
+             else
+                 COMMAND+=" CC='ccache $HOME/gcc-32/bin/${GCC32}-gcc'"
              fi
          fi
          ${COMMAND}

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
 
          echo "::group:: Installing Building Depend Packages"
          "$SU" apt-get update
-         "$SU" apt-get install --no-install-recommends -y binutils git make bc bison openssl curl zip kmod cpio flex libelf-dev libssl-dev libtfm-dev libc6-dev device-tree-compiler ca-certificates python3 xz-utils libc6-dev aria2 build-essential ccache
+         "$SU" apt-get install --no-install-recommends -y binutils git make bc bison openssl curl zip kmod cpio flex libelf-dev libssl-dev libtfm-dev libc6-dev device-tree-compiler ca-certificates python3 xz-utils libc6-dev aria2 build-essential ccache pigz
          aria2c -q https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh && NONINTERACTIVE=1 bash ./uninstall.sh -f -q
          echo "::endgroup::"
          export SWAP_FILE=$(swapon --show=NAME | tail -n 1)

--- a/action.yml
+++ b/action.yml
@@ -225,11 +225,11 @@ runs:
              if [ ${{ inputs.aosp-gcc }} = true ]; then
                  mkdir $HOME/clang -p -v
                  if [ ! -z ${{ inputs.android-version }} ]; then
-                     aria2c -o aosp-clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/android${{ inputs.android-version }}-release/clang-${{ inputs.aosp-clang-version }}.tar.gz
+                     export AOSP_CLANG_URL="https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/android${{ inputs.android-version }}-release/clang-${{ inputs.aosp-clang-version }}.tar.gz"
                  else
-                     aria2c -o aosp-clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/main/clang-${{ inputs.aosp-clang-version }}.tar.gz
+                     export AOSP_CLANG_URL="https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/main/clang-${{ inputs.aosp-clang-version }}.tar.gz"
                  fi
-                 tar -C $HOME/clang -zxf aosp-clang.tar.gz
+                 download_and_extract "$AOSP_CLANG_URL" "aosp-clang" "$HOME/clang"
              else
                  echo "Please enable aosp-gcc."
                  exit 127
@@ -245,15 +245,15 @@ runs:
          if [ ${{ inputs.aosp-gcc }} = true ]; then
              echo "::group:: Downloading AOSP GCC"
              if [ ! -z ${{ inputs.android-version }} ]; then
-                 git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/ --depth=1 -b android${{ inputs.android-version }}-release $HOME/gcc-64
-                 git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/ --depth=1 -b android${{ inputs.android-version }}-release $HOME/gcc-32
+                 export AOSP_GCC64_URL="https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9"
+                 export AOSP_GCC32_URL="https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9"
+                 export AOSP_GCC_BRANCH="android${{ inputs.android-version }}-release"
              else
-                 mkdir -p -v $HOME/gcc-64 $HOME/gcc-32
-                 aria2c -o gcc-aarch64.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz
-                 tar -C $HOME/gcc-64 -zxf gcc-aarch64.tar.gz
-                 aria2c -o gcc-arm.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz
-                 tar -C $HOME/gcc-32 -zxf gcc-arm.tar.gz
+                 export AOSP_GCC64_URL="https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz"
+                 export AOSP_GCC32_URL="https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz"
              fi
+             download_and_extract "$AOSP_GCC64_URL" "gcc-aarch64" "$HOME/gcc-64" "$AOSP_GCC_BRANCH"
+             download_and_extract "$AOSP_GCC32_URL" "gcc-arm" "$HOME/gcc-32" "$AOSP_GCC_BRANCH"
          elif [ ! -z ${{ inputs.other-gcc64-url }} ] || [ ! -z ${{ inputs.other-gcc32-url }} ]; then
              echo "::group:: Downloading Third party GCC"
                  export OTHER_GCC64_URL=${{ inputs.other-gcc64-url }}

--- a/action.yml
+++ b/action.yml
@@ -91,8 +91,8 @@ inputs:
     default: false
   aosp-gcc:
     description: 'Use gcc from aosp project.'
-    required: true
-    default: true
+    required: false
+    default: false
   other-gcc32-url:
     required: false
     default: ''
@@ -239,34 +239,26 @@ runs:
          echo "::endgroup::"
 
          if [ ${{ inputs.aosp-gcc }} = true ]; then
-             if [ ! -z ${{ inputs.other-gcc64-url }} ] || [ ! -z ${{ inputs.other-gcc32-url }} ]; then
-                 echo "::group:: Downloading Third party gcc"
-                 if [ ! -z ${{ inputs.other-gcc64-url }} ] && [ ! -z ${{ inputs.other-gcc32-url }} ]; then
-                     if [ -d $HOME/clang ]; then
-                         export OTHER_GCC64_URL=${{ inputs.other-gcc64-url }}
-                         export OTHER_GCC32_URL=${{ inputs.other-gcc32-url }}
-                         download_and_extract "$OTHER_GCC64_URL" "gcc-aarch64" "$HOME/gcc-64" "${{ inputs.other-gcc64-branch }}"
-                         download_and_extract "$OTHER_GCC32_URL" "gcc-arm" "$HOME/gcc-32" "${{ inputs.other-gcc32-branch }}"
-                     fi
-                 else
-                     echo "Error: Please enable third party 'gcc64-url' and 'gcc32-url', and ensure that 'clang' directory exists." && exit 15
-                 fi
+             echo "::group:: Downloading AOSP GCC"
+             if [ ! -z ${{ inputs.android-version }} ]; then
+                 git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/ --depth=1 -b android${{ inputs.android-version }}-release $HOME/gcc-64
+                 git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/ --depth=1 -b android${{ inputs.android-version }}-release $HOME/gcc-32
              else
-                 echo "::group:: Downloading AOSP GCC"
-                 if [ -d $HOME/clang ]; then
-                     mkdir -p -v $HOME/gcc-64 $HOME/gcc-32
-                     aria2c -o gcc-aarch64.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz
-                     tar -C $HOME/gcc-64 -zxf gcc-aarch64.tar.gz
-                     aria2c -o gcc-arm.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz
-                     tar -C $HOME/gcc-32 -zxf gcc-arm.tar.gz
-                 else
-                     git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/ --depth=1 -b android${{ inputs.android-version }}-release $HOME/gcc-64
-                     git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/ --depth=1 -b android${{ inputs.android-version }}-release $HOME/gcc-32
-                 fi
+                 mkdir -p -v $HOME/gcc-64 $HOME/gcc-32
+                 aria2c -o gcc-aarch64.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz
+                 tar -C $HOME/gcc-64 -zxf gcc-aarch64.tar.gz
+                 aria2c -o gcc-arm.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz
+                 tar -C $HOME/gcc-32 -zxf gcc-arm.tar.gz
              fi
-             [ ! -d $HOME/gcc-64/bin/ ] && mv $HOME/gcc-64/*/* $HOME/gcc-64/
-             [ ! -d $HOME/gcc-32/bin/ ] && mv $HOME/gcc-32/*/* $HOME/gcc-32/
+         elif [ ! -z ${{ inputs.other-gcc64-url }} ] || [ ! -z ${{ inputs.other-gcc32-url }} ]; then
+             echo "::group:: Downloading Third party GCC"
+                 export OTHER_GCC64_URL=${{ inputs.other-gcc64-url }}
+                 export OTHER_GCC32_URL=${{ inputs.other-gcc32-url }}
+                 download_and_extract "$OTHER_GCC64_URL" "gcc-aarch64" "$HOME/gcc-64" "${{ inputs.other-gcc64-branch }}"
+                 download_and_extract "$OTHER_GCC32_URL" "gcc-arm" "$HOME/gcc-32" "${{ inputs.other-gcc32-branch }}"
          fi
+         [ ! -d $HOME/gcc-64/bin/ ] && mv $HOME/gcc-64/*/* $HOME/gcc-64/
+         [ ! -d $HOME/gcc-32/bin/ ] && mv $HOME/gcc-32/*/* $HOME/gcc-32/
          echo "::endgroup::"
 
          echo "::group:: Pulling Kernel Source"

--- a/action.yml
+++ b/action.yml
@@ -300,10 +300,6 @@ runs:
              done
          fi
 
-         [ ! -d "$HOME/gcc-64/aarch64-linux-android" ] && rm -vf "$HOME/gcc-64/bin/${GCC64}-ld"
-         [ ! -d "$HOME/gcc-32/arm-linux-androideabi" ] && rm -vf "$HOME/gcc-32/bin/${GCC32}-ld"
-         ! grep -qsi "LD *= *ld.lld" Makefile && [ -f "$HOME/clang/bin/ld" ] && rm -vf "$HOME/clang/bin/ld"
-
          function version_gt() { test "$(echo -e "$1\n$2" | sort -V | tail -n1)" == "$1"; }
          VERSION=$(grep -E '^VERSION = ' Makefile | awk '{print $3}')
          PATCHLEVEL=$(grep -E '^PATCHLEVEL = ' Makefile | awk '{print $3}')


### PR DESCRIPTION
<!--If you just want to compile the kernel, please do not submit PR after modification!-->
## Title
Add support to compile using third-party GCC and little changes

## Description
Successful build (compiled with EvaGCC 15.0.0): https://github.com/frstprjkt/kernel_dump/actions/runs/12540970748/job/34969276041

Linux version 4.19.327-perf-g0c2afd8be1f2-dirty (runner@fv-az1680-128) (aarch64-elf-gcc (Eva GCC) 15.0.0 20241229 (Bleeding Edge), GNU ld (Eva Binutils) 2.43.50) #1 SMP PREEMPT Mon Dec 30 02:52:24 UTC 2024

## Type
- [x] bug fix 

- [x] feature add 

- [x] other 

## Checkbox
- [x] do not have break changes 

- [x] normal operation will not be affected after modification 

## Linked issues
<!-- if want to fix it, try "fixes: #13">
