### PR TITLE
actions: fix release bug affecting id:release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -487,11 +487,12 @@ runs:
             test -f out/arch/${{ inputs.arch }}/boot/dtbo.img && cp -v out/arch/${{ inputs.arch }}/boot/dtbo.img AnyKernel3/
 
             rm -rf -v AnyKernel3/.git* AnyKernel3/README.md
+            mkdir -p -v ../../build
             if [ ${{ inputs.release }} = false ]; then
                 cp AnyKernel3 ../../build -r -v
             else
                 zip Anykernel3-flasher.zip AnyKernel3/*
-                mv Anykernel3-flasher.zip ../../build -v
+                mv -v Anykernel3-flasher.zip ../../build/
             fi
             echo "::endgroup::"
          fi


### PR DESCRIPTION
when inputs.anykernel3=true && inputs.release=true the mv command renames the zip file as ../../build instead of moving the zip file to ../../build.

when id:release runs and searches for the files in build to upload it does not find that directory and causes an error in uploading the zip file resulting in a missing zip file attachment on the release page.

<!--If you just want to compile the kernel, please do not submit PR after modification!-->

## Type
- [x] bug fix 

- [ ] feature add 

- [ ] other 

## Checkbox
- [x] do not have break changes 

- [x] normal operation will not be affected after modification 

## Linked issues
<!-- if want to fix it, try "fixes: #13">
