### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,6 +56,8 @@ jobs:
 
   sh-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/dabao1955/kernel_build_action/security/code-scanning/1](https://github.com/dabao1955/kernel_build_action/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `sh-check` job. Since the job only performs linting tasks, it does not require write permissions. The minimal permission required is `contents: read`, which allows the job to read the repository's contents without granting any write access. This change ensures that the `GITHUB_TOKEN` is restricted to the least privilege necessary for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
