### PR TITLE
Fix the error:`sed: -e expression #1, char 1004: unexpected `}'`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -327,7 +327,7 @@ runs:
                     echo "CONFIG_KPROBES is enabled, skip patch."
                 else
                     aria2c -q https://github.com/dabao1955/kernel_build_action/raw/main/kernelsu/patch.sh
-                    grep -qs "may_mandlock(void)" fs/namespace.c || sed -i '110s|}}||' patch.sh; bash patch.sh
+                    grep -qs "may_mandlock(void)" fs/namespace.c || sed -i '112s|}}||' patch.sh; bash patch.sh
                 fi
             fi
             echo "::endgroup::"


### PR DESCRIPTION
<!--If you just want to compile the kernel, please do not submit PR after modification!-->
## Title

## Description

## Type
- [ ] bug fix 

- [ ] feature add 

- [ ] other 

## Checkbox
- [ ] do not have break changes 

- [ ] normal operation will not be affected after modification 

## Linked issues
<!-- if want to fix it, try "fixes: #13">
