### PR TITLE
Fix typo in ARM binutils package name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -217,7 +217,7 @@ runs:
             fi
             echo "::endgroup::"
         else
-            SU apt-get install -y clang lld binutils-aarch64-linux-gnu binutils-arm-linux-gnuabeihf
+            SU apt-get install -y clang lld binutils-aarch64-linux-gnu binutils-arm-linux-gnueabihf
         fi
 
         if [ "${{ inputs.aosp-gcc }}" == "true" ] || [ -n "${NEED_GCC:-}" ]; then


### PR DESCRIPTION
Corrected the package name from 'binutils-arm-linux-gnuabeihf' to 'binutils-arm-linux-gnueabihf' in the apt-get install command.

The typo was causing APT package installation failures with the error 'Unable to locate package binutils-arm-linux-gnuabeihf'.

Fixes #153

<!--If you just want to compile the kernel, please do not submit PR after modification!-->
## Title

## Description

## Type
- [ ] bug fix 

- [ ] feature add 

- [ ] other 

## Checkbox
- [ ] do not have break changes 

- [ ] normal operation will not be affected after modification 

## Linked issues
<!-- if want to fix it, try "fixes: #13">
